### PR TITLE
Correcting incorrect tar/gz filename

### DIFF
--- a/LinuxPSSDiag/stop_collector.sh
+++ b/LinuxPSSDiag/stop_collector.sh
@@ -197,7 +197,7 @@ fi
 
         echo "============ Creating a compressed archive of all log files ==========="
 	#zip up output directory
-	tar -zcf "output_${HOSTNAME}_${NOW}.tar.bz2" output
+	tar -zcf "output_${HOSTNAME}_${NOW}.tar.gz" output
 	echo -e "***Data collected is in the file output_${HOSTNAME}_${NOW}.tar.bz2 ***"
 
 


### PR DESCRIPTION
we create a gzipped tar, but name it .bz2.... fixing filename

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - SQL Server 2017
 - SQL Server 2019
 - Azure SQL Virtual Machine
 - Amazon RDS
 
